### PR TITLE
feat: send tx with sponsorship from pimlico paymaster

### DIFF
--- a/apps/web/src/components/UserSummary.tsx
+++ b/apps/web/src/components/UserSummary.tsx
@@ -2,13 +2,24 @@ import { useBalance, useUserReservesIncentives } from '@/api';
 import React from 'react';
 import { Spinner } from './Spinner';
 import { AddressButton, Card } from '.';
-import { useLfghoClients } from '@repo/lfgho-sdk';
+import { useLfghoClients, useTurnkeyViem } from '@repo/lfgho-sdk';
+import { Address, Hex, encodeFunctionData } from 'viem';
+import { erc20ABI } from 'wagmi';
+import { Interface } from 'ethers/lib/utils';
+import { sendTransactionWithSponsor } from '../../../../packages/lfgho-sdk/src/_pimlico';
 
 type Props = {
     address: string;
 };
 export const UserSummary: React.FC<Props> = ({ address }) => {
-    const { ethersProvider } = useLfghoClients();
+    const {
+        ethersProvider,
+        pimlicoBundler,
+        pimlicoPaymaster,
+        viemPublicClient
+    } = useLfghoClients();
+
+    const { getViemInstance } = useTurnkeyViem();
 
     const { data: balance } = useBalance(ethersProvider, address);
     const { data: userReservesIncentives } = useUserReservesIncentives(address);
@@ -23,11 +34,42 @@ export const UserSummary: React.FC<Props> = ({ address }) => {
             </Card>
         );
 
+    const transferETH = async () => {
+        const iface = new Interface(erc20ABI); 
+
+        const passkeyAccount = (await getViemInstance()).account;
+
+        const entryPoint = (await pimlicoBundler.supportedEntryPoints())?.[0];
+
+        await sendTransactionWithSponsor(
+            "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0", //USDT
+            iface,
+            "transfer",
+            [
+                '0x3427034D30c9306F95715C6b14690587584cCEDF',
+                1000000n
+            ],
+            0n,
+            address as Address,
+            pimlicoBundler,
+            pimlicoPaymaster,
+            viemPublicClient,
+            passkeyAccount,
+            entryPoint
+        );
+    };
+
     return (
         <Card>
             <div className="flex flex-row justify-between">
                 <span className="text-2xl font-bold">User Summary (AA)</span>
                 <AddressButton address={address} withCopy={true} />
+                <button
+                    className="border-2 border-black rounded-xl px-2 py-1 ml-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                    onClick={transferETH}
+                >
+                    SEND
+                </button>
             </div>
             <div className="flex flex-row justify-between items-center">
                 <span className="text-xl">ETH Balance</span>

--- a/packages/lfgho-sdk/src/_pimlico/api/buildUserOperation.ts
+++ b/packages/lfgho-sdk/src/_pimlico/api/buildUserOperation.ts
@@ -23,14 +23,6 @@ export const buildUserOperation = async ({
     const gasPriceResult = await bundlerClient.getUserOperationGasPrice();
     const nonce = await getAccountNonce(publicClient, { entryPoint, sender });
 
-    if (nonce !== 0n) {
-        console.log(
-            'Deployment UserOperation previously submitted, skipping...'
-        );
-
-        return;
-    }
-
     const userOperation: Partial<UserOperation> = {
         sender,
         nonce,
@@ -40,7 +32,7 @@ export const buildUserOperation = async ({
         maxFeePerGas: gasPriceResult.fast.maxFeePerGas,
         maxPriorityFeePerGas: gasPriceResult.fast.maxPriorityFeePerGas,
         signature:
-            '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c',
+            '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c', // Dummy signature
         ...rest
     };
 

--- a/packages/lfgho-sdk/src/_pimlico/api/sendTransactionWithSponsor.ts
+++ b/packages/lfgho-sdk/src/_pimlico/api/sendTransactionWithSponsor.ts
@@ -1,0 +1,87 @@
+import {
+    PimlicoBundlerClient,
+    PimlicoPaymasterClient
+} from 'permissionless/clients/pimlico';
+import { Address, Hex, LocalAccount, PublicClient, encodeFunctionData } from 'viem';
+import { buildUserOperation } from './buildUserOperation';
+import { UserOperation } from 'permissionless';
+import { signUserOperationWithPasskey } from '.';
+import { sepolia } from 'viem/chains';
+import { type Interface } from 'ethers/lib/utils';
+
+export const sendTransactionWithSponsor = async (
+    contractAddress: Address,
+    contractInterface: Interface,
+    contractMethod: string,
+    contractMethodArgs: unknown[],
+    txValue: bigint,
+    smartAccountAddress: Address,
+    bundlerClient: PimlicoBundlerClient,
+    paymasterClient: PimlicoPaymasterClient,
+    publicClient: PublicClient,
+    passkeyAccount: LocalAccount,
+    entrypointAddress: Address,
+) => {
+    const callData = encodeFunctionData({
+        abi: [
+            {
+                inputs: [
+                    { name: 'dest', type: 'address' },
+                    { name: 'value', type: 'uint256' },
+                    { name: 'func', type: 'bytes' }
+                ],
+                name: 'execute',
+                outputs: [],
+                stateMutability: 'nonpayable',
+                type: 'function'
+            }
+        ],
+        args: [
+            contractAddress,
+            txValue,
+            contractInterface.encodeFunctionData(contractMethod, contractMethodArgs) as Hex
+        ]
+    });
+
+    let userOperation: UserOperation = (await buildUserOperation({
+        sender: smartAccountAddress,
+        entryPoint: entrypointAddress,
+        initCode: "0x",
+        callData,
+        bundlerClient,
+        publicClient
+    })) as UserOperation;
+
+    console.log('Built userOperation:', userOperation);
+
+    // Sponsor the useroperation
+    const sponsorParams = await paymasterClient.sponsorUserOperation({
+        userOperation,
+        entryPoint: entrypointAddress
+    });
+
+    userOperation = { ...userOperation, ...sponsorParams };
+    console.log('Sponsored userOperation:', userOperation);
+
+    const signature = await signUserOperationWithPasskey({
+        viemAccount: passkeyAccount,
+        userOperation,
+        entryPoint: entrypointAddress,
+        chain: sepolia
+    });
+    userOperation = { ...userOperation, signature };
+    console.log('Signed userOperation:', userOperation);
+
+    // Send the useroperation
+    const hash = await bundlerClient.sendUserOperation({
+        userOperation,
+        entryPoint: entrypointAddress
+    });
+    console.log('Sent userOperation:', hash);
+
+    console.log('Querying for receipts...');
+    const receipt =
+        await bundlerClient.waitForUserOperationReceipt({ hash });
+    const txHash = receipt.receipt.transactionHash;
+    console.log(`Transaction hash: ${txHash}`);
+};


### PR DESCRIPTION
Example of sending 1 USDT to `0x3427034D30c9306F95715C6b14690587584cCEDF`:

```
 const transferUSDT = async () => {
        const iface = new Interface(erc20ABI); 

        const passkeyAccount = (await getViemInstance()).account;

        const entryPoint = (await pimlicoBundler.supportedEntryPoints())?.[0];

        await sendTransactionWithSponsor(
            "0xaa8e23fb1079ea71e0a56f48a2aa51851d8433d0", //USDT
            iface,
            "transfer",
            [
                '0x3427034D30c9306F95715C6b14690587584cCEDF',
                1000000n
            ],
            0n,
            address as Address,
            pimlicoBundler,
            pimlicoPaymaster,
            viemPublicClient,
            passkeyAccount,
            entryPoint
        );
    };
```